### PR TITLE
Tell the compiler we use printf-style options

### DIFF
--- a/log.c
+++ b/log.c
@@ -119,6 +119,7 @@ void _close_log()
 // mlog_printf - Prints data to the log file
 //***************************************************************
 
+__attribute__((format (printf, 7, 8)))
 int mlog_printf(int suppress_header, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...)
 {
     va_list args;
@@ -235,6 +236,7 @@ void mlog_load(char *fname, char *output_override, int log_level_override)
 // minfo_printf -Does a normal printf
 //***************************************************************
 
+__attribute__((format (printf, 7, 8)))
 int minfo_printf(info_fd_t *ifd, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...)
 {
     va_list args;

--- a/log.h
+++ b/log.h
@@ -66,7 +66,7 @@ info_fd_t *info_create(FILE *fd, int header_type, int level);
 void info_destroy(info_fd_t *fd);
 void flush_info(info_fd_t *fd);
 //int info_printf(info_fd_t *fd, int level, const char *fmt, ...);
-int minfo_printf(info_fd_t *ifd, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...);
+extern int minfo_printf(info_fd_t *ifd, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...) __attribute__((format (printf, 7, 8)));
 void info_flush(info_fd_t *ifd);
 #define info_printf(ifd, n, ...) minfo_printf(ifd, _log_module_index, n, __func__, _mlog_file_table[_log_module_index], __LINE__, __VA_ARGS__)
 #define get_info_header_type(fd) fd->header_type
@@ -90,7 +90,7 @@ extern char _log_fname[1024];
 void _open_log(char *fname, int dolock);
 void _close_log();
 void flush_log();
-int mlog_printf(int suppress_header, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...);
+extern int mlog_printf(int suppress_header, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...) __attribute__((format (printf, 7, 8)));
 void mlog_load(char *fname, char *output_override, int log_level_override);
 
 #ifndef _log_module_index


### PR DESCRIPTION
Trying to sort out some logs, I noticed incorrect type specifiers for
string formatting options. Add function attributes around our logging to
get the compiler to complain early.