### PR TITLE
Add wrapper for constructor/destructor functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(LSTORE_PROJECT_INCLUDES
                 type_malloc.h transfer_buffer.h packer.h append_printf.h
                 chksum.h varint.h atomic_counter.h dns_cache.h iniparse.h
                 log.h assert_result.h)
-set(LSTORE_PROJECT_EXECUTABLES sl_test isl_test varint_test)
+set(LSTORE_PROJECT_EXECUTABLES sl_test isl_test varint_test constructor_test)
 
 # Common functionality is stored here
 include(cmake/LStoreCommon.cmake)

--- a/constructor_test.c
+++ b/constructor_test.c
@@ -1,0 +1,77 @@
+/* Test construction/destruction functionality */
+#include "constructor_wrapper.h"
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int do_print = 0;
+int fd_out = 0;
+int pos = 0;
+char order[] = "XXXX";
+
+#ifdef ACCRE_CONSTRUCTOR_PREPRAGMA_ARGS
+#pragma ACCRE_CONSTRUCTOR_PREPRAGMA_ARGS(construct_fn)
+#endif
+ACCRE_DEFINE_CONSTRUCTOR(construct_fn)
+#ifdef ACCRE_CONSTRUCTOR_POSTPRAGMA_ARGS
+#pragma ACCRE_CONSTRUCTOR_POSTPRAGMA_ARGS(construct_fn)
+#endif
+
+#ifdef ACCRE_DESTRUCTOR_PREPRAGMA_ARGS
+#pragma ACCRE_DESTRUCTOR_PREPRAGMA_ARGS(destruct_fn)
+#endif
+ACCRE_DEFINE_DESTRUCTOR(destruct_fn)
+#ifdef ACCRE_DESTRUCTOR_POSTPRAGMA_ARGS
+#pragma ACCRE_DESTRUCTOR_POSTPRAGMA_ARGS(destruct_fn)
+#endif
+
+static void construct_fn() {
+    order[pos++] = '1';
+}
+
+static void destruct_fn() {
+    order[pos++] = '3';
+    if (do_print) {
+        write(fd_out, order, sizeof(order));
+        write(fd_out, "\n", 1);
+    }
+}
+
+int main(int argc, const char ** argv) {
+    order[pos++] = '2';
+    if (argc > 1) {
+        do_print = 1;
+    } else {
+        int fd[2];
+        if (pipe(fd))
+            return 1;
+        pid_t pid = fork();
+        if (pid < 0) {
+            return 1;
+        } else if (pid == 0) {
+            close(0);
+            close(fd[0]);
+            dup2(fd[1], 0);
+            execl(argv[0], argv[0], "1", (char *) NULL);
+            _exit(EXIT_FAILURE);
+        } else {
+            close(fd[1]);
+            int status;
+            waitpid(pid, &status, 0);
+            if (status)
+                return status;
+            char wanted[] = "123X";
+            char buf[sizeof(wanted) + 1];
+            int flags = fcntl(fd[0], F_GETFL, 0);
+            fcntl(fd[0], F_SETFL, flags | O_NONBLOCK);
+            ssize_t bytes = read(fd[0], buf, sizeof(wanted) - 1);
+            if (bytes != sizeof(wanted) - 1)
+                return 1;
+            printf("Expected: %s\n", wanted);
+            printf("Received: %s\n", buf);
+            return ((strncmp(buf, wanted, sizeof(wanted) - 1) == 0) ? 0 : 1);
+        }
+    }
+    return 0;
+}

--- a/constructor_wrapper.h
+++ b/constructor_wrapper.h
@@ -1,0 +1,122 @@
+/*
+ * We occasionally need to perform menial initialization/destruction tasks to
+ * set up the environment for subsystems. For instance, subsystem 'foo' needs
+ * an APR pool to work, so it has init_foo()/destroy_foo(). Problem is, any
+ * code using these subsystems need to both know about this requirement and
+ * implement it properly. Done right, it's obnoxious. Done wrong, it's either a
+ * leak or a crash waiting to happen.
+ *
+ * Standard C doesn't have any way around it, but most (all?) compilers/targets
+ * support marking certain functions to be run before/after main() is executed.
+ * Subsystems can exploit this functionality to ensure their
+ * constructors/destructors are properly executed without depending on someone
+ * else.
+ *
+ * The following example use will execute construct_fn/destruct_fn before/after
+ * main():
+ * 
+ *    #include "constructor_wrapper.h"
+ *    #ifdef ACCRE_CONSTRUCTOR_PREPRAGMA_ARGS
+ *    #pragma ACCRE_CONSTRUCTOR_PREPRAGMA_ARGS(construct_fn)
+ *    #endif
+ *    ACCRE_DEFINE_CONSTRUCTOR(construct_fn)
+ *    #ifdef ACCRE_CONSTRUCTOR_POSTPRAGMA_ARGS
+ *    #pragma ACCRE_CONSTRUCTOR_POSTPRAGMA_ARGS(construct_fn)
+ *    #endif
+ *    
+ *    #ifdef ACCRE_DESTRUCTOR_PREPRAGMA_ARGS
+ *    #pragma ACCRE_DESTRUCTOR_PREPRAGMA_ARGS(destruct_fn)
+ *    #endif
+ *    ACCRE_DEFINE_DESTRUCTOR(destruct_fn)
+ *    #ifdef ACCRE_DESTRUCTOR_POSTPRAGMA_ARGS
+ *    #pragma ACCRE_DESTRUCTOR_POSTPRAGMA_ARGS(destruct_fn)
+ *    #endif
+ *    
+ *    static void construct_fn() {  }
+ *    
+ *    static void destruct_fn() {  }
+ * 
+ * Unfortunately, implementing this under some compilers requires using
+ * #pragma, which cannot be properly nested in a #define. Later C standards
+ * declare a _Pragma() token, which can be used properly (it is handled
+ * properly by the preprocessor). Support isn't universal, so we must do the
+ * #ifdef/#pragma/#endif sequence to properly push/pop pragmas around the
+ * declarations.
+ *    
+ */
+
+#ifndef INCLUDED_ACCRE_TOOLBOX_CONSTRUCTOR_WRAPPER_H
+#define INCLUDED_ACCRE_TOOLBOX_CONSTRUCTOR_WRAPPER_H
+#include <stdlib.h>
+
+#if  __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 7) // Building with GCC
+#  define ACCRE_DEFINE_CONSTRUCTOR(func_name) \
+     static void __attribute__((constructor)) func_name(void);
+#  define ACCRE_DEFINE_DESTRUCTOR(func_name) \
+     static void __attribute__((destructor)) func_name(void);
+#elif defined(_MSC_VER) // Building with MSVC
+#  warn "Constructor/Destructor support for MSVC is untested"
+#  if(_MSC_VER >= 1500)
+#    warn "Constructors/Destructors under VS2015 may behave weird under \n" \
+          "Whole-program optimization."
+#    ifndef _WIN64
+#      warn "Constructors/Destructors may not work under x86 due to mangling"
+#    endif
+#    define ACCRE_DEFINE_CONSTRUCTOR(func_name) \
+       static void func_name(void); \
+       int func_name ## _accre_wrapper(void) { func_name(); return 0; } \
+	   __pragma(comment(linker,"/include:" func_name "_accre_wrapper")) \
+	   __pragma(section(".CRT$XCU",read)) \
+	   __declspec(allocate(".CRT$XCU")) \
+       static int (* _KEEP ## func_name)(void) = func_name ## _accre_wrapper;
+
+#    define ACCRE_DEFINE_DESTRUCTOR(func_name) \
+       static void func_name(void); \
+       int func_name ## _accre_wrapper(void) { \
+                                                    atexit(func_name); \
+                                                    return 0; } \
+       __pragma(comment(linker,"/include:" func_name "_accre_wrapper")) \
+	   __pragma(section(".CRT$XCU",read)) \
+	   __declspec(allocate(".CRT$XCU")) \
+       static int (* _KEEP ## func_name)(void) = func_name ## _accre_wrapper;
+
+#  elif(_MSC_VER >= 1400) // MSVC8
+#    define ACCRE_DEFINE_CONSTRUCTOR(func_name) \
+       static void func_name(void); \
+       static int func_name ## _accre_wrapper(void) { func_name(); return 0; } \
+       __declspec(allocate(".CRT$XCU")) \
+         static int (* _KEEP ## func_name)(void) = func_name ## _accre_wrapper;
+
+#    define ACCRE_DEFINE_DESTRUCTOR(func_name) \
+       static void func_name(void); \
+       static int func_name ## _accre_wrapper(void) { \
+                                                    atexit(func_name); \
+                                                    return 0; } \
+       __declspec(allocate(".CRT$XPU")) \
+         static int (* _KEEP ## func_name)(void) = func_name ## _accre_wrapper;
+#    define ACCRE_CONSTRUCTOR_PREPRAGMA_ARGS(func_name) section(".CRT$XCU",read)
+#    define ACCRE_DESTRUCTOR_PREPRAGMA_ARGS(func_name) section(".CRT$XPU",read)
+#  else // MSVC < MSVC8
+#    define ACCRE_DEFINE_CONSTRUCTOR(func_name) \
+       static void func_name(void); \
+       static int func_name ## _accre_wrapper(void) { func_name(); return 0; } \
+       static int (* _KEEP ## func_name)(void) = func_name ## _accre_wrapper;
+
+#    define ACCRE_DEFINE_DESTRUCTOR(func_name) \
+       static void func_name(void); \
+       static int func_name ## _accre_wrapper(void) { \
+                                                    atexit(func_name); \
+                                                    return 0; } \
+       static int (* _KEEP ## func_name)(void) = func_name ## _accre_wrapper;
+#    define ACCRE_CONSTRUCTOR_PREPRAGMA_ARGS(func_name) data_seg(".CRT$XCU")
+#    define ACCRE_DESTRUCTOR_PREPRAGMA_ARGS(func_name) data_seg(".CRT$XPU")
+#    define ACCRE_CONSTRUCTOR_POSTPRAGMA_ARGS(func_name) data_seg()
+#    define ACCRE_DESTRUCTOR_POSTPRAGMA_ARGS(func_name) data_seg()
+#  endif // MSVC version selection
+#endif // Compiler selection
+
+#ifndef ACCRE_DEFINE_CONSTRUCTOR
+#  error "This platform lacks Constructor/Destructor support"
+#endif
+
+#endif // Include guard


### PR DESCRIPTION
Wrap (ahem, attempt to wrap) around compiler differences for specifying
constructor and destructor functions. These functions are executed
automatically on program execution and regular (not abnormal)
termination.

This will let base initialization (like allocating APR pools) happen
without all other code users manually calling "init_XXX()" or forcing
code who needs initialization to do "if (!initialized) init_XXX()"

Tested with GCC, Clang. The MSVC support was implemented by studying
other implementations and _should_ work, but is untested.
